### PR TITLE
Removed Gospel buffs on logout

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2089,6 +2089,14 @@ int map_quit(struct map_session_data *sd) {
 			status_change_end(&sd->bl, SC_PRESERVE, INVALID_TIMER);
 			status_change_end(&sd->bl, SC_KAAHI, INVALID_TIMER);
 			status_change_end(&sd->bl, SC_SPIRIT, INVALID_TIMER);
+			status_change_end(&sd->bl, SC_SCRESIST, INVALID_TIMER);
+			status_change_end(&sd->bl, SC_INCMHPRATE, INVALID_TIMER);
+			status_change_end(&sd->bl, SC_INCMSPRATE, INVALID_TIMER);
+			status_change_end(&sd->bl, SC_INCALLSTATUS, INVALID_TIMER);
+			status_change_end(&sd->bl, SC_INCDEFRATE, INVALID_TIMER);
+			status_change_end(&sd->bl, SC_INCATKRATE, INVALID_TIMER);
+			status_change_end(&sd->bl, SC_INCHIT, INVALID_TIMER);
+			status_change_end(&sd->bl, SC_INCFLEE, INVALID_TIMER);
 			status_change_end(&sd->bl, SC_HEAT_BARREL, INVALID_TIMER);
 			status_change_end(&sd->bl, SC_P_ALTER, INVALID_TIMER);
 			status_change_end(&sd->bl, SC_E_CHAIN, INVALID_TIMER);


### PR DESCRIPTION
* Fixes #3426.
* Remove miscellaneous buffs given by Gospel on logout to prevent stacking.
Thanks to @FriggRM and @mrjnumber1!

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
